### PR TITLE
Added hack to get url building working on Windows

### DIFF
--- a/lib/utils/exposeLists.js
+++ b/lib/utils/exposeLists.js
@@ -12,6 +12,9 @@ module.exports = function exposeLists( keystone,
     var restConfig = parseConfig( list, config.resources[ key ] );
     if( !restConfig.hidden ){
       var entry = path.join( config.root, restConfig.path );
+      //Windows hack: path.join will return windows path file separator "\ instead of url based separator "/"
+      //This helps explain the issue: http://stackoverflow.com/questions/12722865/using-path-join-on-nodejs-on-windows-to-create-url
+      entry = entry.replace(/\\/g, '/');
       var methods = restConfig.methods;
       output[ key ] = {};
       _.each( methods, function( methodName ){

--- a/lib/utils/exposeLists.js
+++ b/lib/utils/exposeLists.js
@@ -14,7 +14,7 @@ module.exports = function exposeLists( keystone,
       var entry = path.join( config.root, restConfig.path );
       //Windows hack: path.join will return windows path file separator "\ instead of url based separator "/"
       //This helps explain the issue: http://stackoverflow.com/questions/12722865/using-path-join-on-nodejs-on-windows-to-create-url
-      entry = entry.replace(/\\/g, '/');
+      entry = entry.replace( /\\/g, '/' );
       var methods = restConfig.methods;
       output[ key ] = {};
       _.each( methods, function( methodName ){


### PR DESCRIPTION
path.join will return windows path file separator "\ instead of url based separator "/".

http://stackoverflow.com/questions/12722865/using-path-join-on-nodejs-on-windows-to-create-url

Please note:

I only tested this on Windows.
