### PR TITLE
Fix to list method API generation

### DIFF
--- a/lib/utils/getId.js
+++ b/lib/utils/getId.js
@@ -1,5 +1,5 @@
 "use strict";
 
 module.exports = function( req ){
-  return req.params[ "id" ] || req.query[ "id" ] || req.body[ "id" ];
+  return req.params[ "id" ] || req.query[ "id" ] || ( req.body && req.body[ "id" ] );
 };


### PR DESCRIPTION
Was trying to generate an API for a keystone.list named Clause exposing two methods 'list' and 'retrieve'.

Retrieve works okay with the form GET /api/clauses/XXXXXX though was having trouble with the list method GET /api/clauses

The getId.js util is accessing the request's body for an id property though in the case of a 'list'/GET request there is no body to be found so the method ends up throwing a TypeError while looking up the ['id'] property on undefined.

keystone version: 0.3.14
restful-keystone version: 0.3.0

```
TypeError: Cannot read property 'id' of undefined
    at module.exports (..../keystone-cms/node_modules/restful-keystone/lib/utils/getId.js:4:61)
    at handle (..../keystone-cms/node_modules/restful-keystone/lib/methods/list.js:23:16)
    at Layer.handle [as handle_request] (..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/layer.js:95:5)
    at next (..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/route.js:131:13)
    at Route.dispatch (..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/layer.js:95:5)
    at ..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/index.js:277:22
    at Function.process_params (..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/index.js:330:12)
    at next (..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/index.js:271:10)
    at expressInit (..../keystone-cms/node_modules/keystone/node_modules/express/lib/middleware/init.js:33:5)
    at Layer.handle [as handle_request] (..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/index.js:312:13)
    at ..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/index.js:330:12)
    at next (..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/index.js:271:10)
    at query (..../keystone-cms/node_modules/keystone/node_modules/express/lib/middleware/query.js:49:5)
    at Layer.handle [as handle_request] (..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/index.js:312:13)
    at ..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/index.js:330:12)
    at next (..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/index.js:271:10)
    at Function.handle (..../keystone-cms/node_modules/keystone/node_modules/express/lib/router/index.js:176:3)
    at EventEmitter.handle (..../keystone-cms/node_modules/keystone/node_modules/express/lib/application.js:173:10)
    at Server.app (..../keystone-cms/node_modules/keystone/node_modules/express/lib/express.js:38:9)
    at Server.emit (events.js:110:17)
    at HTTPParser.parserOnIncoming [as onIncoming] (_http_server.js:491:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:111:23)
    at Socket.socketOnData (_http_server.js:343:22)
```
