### PR TITLE
Allow configuring of populate for multiple fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Will only operate on Article documents that have a `"published"` value in `"stat
 
 ##### `populate`
 
-**{Boolean|String|String[]}** default: `false`
+**{Boolean|String|String[]|Object[]}** default: `false`
 
 Allows automatic population of relationship fields.
 

--- a/lib/methods/list.js
+++ b/lib/methods/list.js
@@ -44,8 +44,8 @@ module.exports = function( list,
         config.populate = [ config.populate ];
       }
       filter = deepMerge( config.filter, filter || {} );
-      config.limit = parseInt(req.query.limit) || config.limit || 10;
-      config.skip = parseInt(req.query.skip) || config.skip || 0;
+      config.limit = parseInt( req.query.limit ) || config.limit || 10;
+      config.skip = parseInt( req.query.skip ) || config.skip || 0;
       list.model.find( filter, config.show, config )
         .exec()
         .then( function( result ){

--- a/lib/methods/list.js
+++ b/lib/methods/list.js
@@ -37,14 +37,12 @@ module.exports = function( list,
       if( _.isFunction( config.filter ) ){
         config.filter = config.filter();
       }
-      
-      if (_.isArray(config.populate)
-        && config.populate.length > 0
-        && _.isObject(config.populate[0])
+      if ( _.isArray( config.populate )
+        && 0 < config.populate.length
+        && _.isObject( config.populate[0] )
       ) {
         config.populate = [config.populate];
       }
-
       filter = deepMerge( config.filter, filter || {} );
       list.model.find( filter, config.show, config )
         .exec()

--- a/lib/methods/list.js
+++ b/lib/methods/list.js
@@ -44,8 +44,16 @@ module.exports = function( list,
         config.populate = [ config.populate ];
       }
       filter = deepMerge( config.filter, filter || {} );
-      config.limit = parseInt( req.query.limit ) || config.limit || 10;
-      config.skip = parseInt( req.query.skip ) || config.skip || 0;
+
+      var tempLimit = parseInt( req.query.limit ) || config.limit || null;
+      var tempSkip = parseInt( req.query.skip ) || config.skip || 0;
+
+      // Only apply limit if specified
+      if (null !== tempLimit) {
+        config.limit = tempLimit;
+        config.skip  = tempSkip;
+      }
+
       list.model.find( filter, config.show, config )
         .exec()
         .then( function( result ){

--- a/lib/methods/list.js
+++ b/lib/methods/list.js
@@ -38,6 +38,8 @@ module.exports = function( list,
         config.filter = config.filter();
       }
       filter = deepMerge( config.filter, filter || {} );
+      config.limit = config.limit || parseInt(req.query.limit) || 10;
+      config.skip = config.skip || parseInt(req.query.skip) || 0;
       list.model.find( filter, config.show, config )
         .exec()
         .then( function( result ){

--- a/lib/methods/list.js
+++ b/lib/methods/list.js
@@ -45,16 +45,18 @@ module.exports = function( list,
       }
       filter = deepMerge( config.filter, filter || {} );
 
+      // Ensure limit and skip are per request!
+      var tempConfig = {};
       var tempLimit = parseInt( req.query.limit ) || config.limit || null;
       var tempSkip = parseInt( req.query.skip ) || config.skip || 0;
 
       // Only apply limit if specified
       if ( null !== tempLimit ) {
-        config.limit = tempLimit;
-        config.skip  = tempSkip;
+        tempConfig.limit = tempLimit;
+        tempConfig.skip  = tempSkip;
       }
 
-      list.model.find( filter, config.show, config )
+      list.model.find( filter, config.show, deepMerge( config, tempConfig ) )
         .exec()
         .then( function( result ){
           result = handleResult( result || [], config );

--- a/lib/methods/list.js
+++ b/lib/methods/list.js
@@ -38,8 +38,8 @@ module.exports = function( list,
         config.filter = config.filter();
       }
       filter = deepMerge( config.filter, filter || {} );
-      config.limit = config.limit || parseInt(req.query.limit) || 10;
-      config.skip = config.skip || parseInt(req.query.skip) || 0;
+      config.limit = parseInt(req.query.limit) || config.limit || 10;
+      config.skip = parseInt(req.query.skip) || config.skip || 0;
       list.model.find( filter, config.show, config )
         .exec()
         .then( function( result ){

--- a/lib/methods/list.js
+++ b/lib/methods/list.js
@@ -41,7 +41,7 @@ module.exports = function( list,
         && 0 < config.populate.length
         && _.isObject( config.populate[0] )
       ) {
-        config.populate = [config.populate];
+        config.populate = [ config.populate ];
       }
       filter = deepMerge( config.filter, filter || {} );
       list.model.find( filter, config.show, config )

--- a/lib/methods/list.js
+++ b/lib/methods/list.js
@@ -49,7 +49,7 @@ module.exports = function( list,
       var tempSkip = parseInt( req.query.skip ) || config.skip || 0;
 
       // Only apply limit if specified
-      if (null !== tempLimit) {
+      if ( null !== tempLimit ) {
         config.limit = tempLimit;
         config.skip  = tempSkip;
       }

--- a/lib/methods/list.js
+++ b/lib/methods/list.js
@@ -37,27 +37,24 @@ module.exports = function( list,
       if( _.isFunction( config.filter ) ){
         config.filter = config.filter();
       }
-      if ( _.isArray( config.populate )
-        && 0 < config.populate.length
-        && _.isObject( config.populate[0] )
-      ) {
-        config.populate = [ config.populate ];
+      var options = _.cloneDeep( config );
+      var populateMulti = false;
+      if (_.isArray( options.populate ) ) {
+        populateMulti = options.populate;
+        delete options.populate;
       }
-      filter = deepMerge( config.filter, filter || {} );
-
-      // Ensure limit and skip are per request!
-      var tempConfig = {};
-      var tempLimit = parseInt( req.query.limit ) || config.limit || null;
-      var tempSkip = parseInt( req.query.skip ) || config.skip || 0;
-
-      // Only apply limit if specified
-      if ( null !== tempLimit ) {
-        tempConfig.limit = tempLimit;
-        tempConfig.skip  = tempSkip;
+      filter = deepMerge( options.filter, filter || {} );
+      if ( req.query.limit || options.limit ) {
+        options.limit =  parseInt( req.query.limit ) || options.limit;
+        options.skip = parseInt( req.query.skip ) || options.skip || 0;
       }
-
-      list.model.find( filter, config.show, deepMerge( config, tempConfig ) )
-        .exec()
+      var result = list.model.find( filter, config.show, options );
+      if ( populateMulti ) {
+        _.forEach( populateMulti, function( v ) {
+          result.populate( v );
+        });
+      }
+      result.exec()
         .then( function( result ){
           result = handleResult( result || [], config );
           res.locals.body = result;

--- a/lib/methods/list.js
+++ b/lib/methods/list.js
@@ -37,6 +37,14 @@ module.exports = function( list,
       if( _.isFunction( config.filter ) ){
         config.filter = config.filter();
       }
+      
+      if (_.isArray(config.populate)
+        && config.populate.length > 0
+        && _.isObject(config.populate[0])
+      ) {
+        config.populate = [config.populate];
+      }
+
       filter = deepMerge( config.filter, filter || {} );
       list.model.find( filter, config.show, config )
         .exec()

--- a/lib/utils/exposeLists.js
+++ b/lib/utils/exposeLists.js
@@ -12,6 +12,9 @@ module.exports = function exposeLists( keystone,
     var restConfig = parseConfig( list, config.resources[ key ] );
     if( !restConfig.hidden ){
       var entry = path.join( config.root, restConfig.path );
+      //Windows hack: path.join will return windows path file separator "\ instead of url based separator "/"
+      //This helps explain the issue: http://stackoverflow.com/questions/12722865/using-path-join-on-nodejs-on-windows-to-create-url
+      entry = entry.replace(/\\/g, '/');
       var methods = restConfig.methods;
       output[ key ] = {};
       _.each( methods, function( methodName ){

--- a/lib/utils/exposeLists.js
+++ b/lib/utils/exposeLists.js
@@ -14,7 +14,7 @@ module.exports = function exposeLists( keystone,
       var entry = path.join( config.root, restConfig.path );
       //Windows hack: path.join will return windows path file separator "\ instead of url based separator "/"
       //This helps explain the issue: http://stackoverflow.com/questions/12722865/using-path-join-on-nodejs-on-windows-to-create-url
-      entry = entry.replace(/\\/g, '/');
+      entry = entry.replace( /\\/g, '/' );
       var methods = restConfig.methods;
       output[ key ] = {};
       _.each( methods, function( methodName ){

--- a/lib/utils/parseListConfig.js
+++ b/lib/utils/parseListConfig.js
@@ -14,7 +14,7 @@ module.exports = function parseListConfig( list,
     config.edit = parseMixedValue( config.edit, fields, [] ).join( " " );
     config.envelop = parseMixedValue( config.envelop, "<%=name%>", "" );
 
-    if ( _.isArray( config.populate ) && config.populate.length > 0 && _.isObject( config.populate[0] ) ) {
+    if ( _.isArray( config.populate ) && 0 < config.populate.length && _.isObject( config.populate[0] ) ) {
       config.populate = config.populate;
     } else {
       config.populate = parseMixedValue( config.populate || false, relationshipFields, [] ).join( " " );

--- a/lib/utils/parseListConfig.js
+++ b/lib/utils/parseListConfig.js
@@ -15,7 +15,7 @@ module.exports = function parseListConfig( list,
     config.envelop = parseMixedValue( config.envelop, "<%=name%>", "" );
 
     if (_.isArray(config.populate) && config.populate.length > 0 && _.isObject(config.populate[0])) {
-     config.populate = config.populate;
+      config.populate = config.populate;
     } else {
       config.populate = parseMixedValue(config.populate || false, relationshipFields, []).join(" ");
     }

--- a/lib/utils/parseListConfig.js
+++ b/lib/utils/parseListConfig.js
@@ -12,8 +12,13 @@ module.exports = function parseListConfig( list,
     config.methods = parseMixedValue( config.methods, constants.METHODS_ALL, [] );
     config.show = parseMixedValue( config.show, fields, [] ).join( " " );
     config.edit = parseMixedValue( config.edit, fields, [] ).join( " " );
-    config.populate = parseMixedValue( config.populate || false, relationshipFields, [] ).join( " " );
     config.envelop = parseMixedValue( config.envelop, "<%=name%>", "" );
+
+    if (_.isArray(config.populate) && config.populate.length > 0 && _.isObject(config.populate[0])) {
+     config.populate = config.populate;
+    } else {
+      config.populate = parseMixedValue(config.populate || false, relationshipFields, []).join(" ");
+    }
 
     config.key = config.key || list.key;
     config.path = config.path || list.path;

--- a/lib/utils/parseListConfig.js
+++ b/lib/utils/parseListConfig.js
@@ -14,10 +14,10 @@ module.exports = function parseListConfig( list,
     config.edit = parseMixedValue( config.edit, fields, [] ).join( " " );
     config.envelop = parseMixedValue( config.envelop, "<%=name%>", "" );
 
-    if (_.isArray(config.populate) && config.populate.length > 0 && _.isObject(config.populate[0])) {
+    if ( _.isArray( config.populate ) && config.populate.length > 0 && _.isObject( config.populate[0] ) ) {
       config.populate = config.populate;
     } else {
-      config.populate = parseMixedValue(config.populate || false, relationshipFields, []).join(" ");
+      config.populate = parseMixedValue( config.populate || false, relationshipFields, [] ).join( " " );
     }
 
     config.key = config.key || list.key;

--- a/lib/utils/parseListConfig.js
+++ b/lib/utils/parseListConfig.js
@@ -15,7 +15,7 @@ module.exports = function parseListConfig( list,
     config.envelop = parseMixedValue( config.envelop, "<%=name%>", "" );
 
     if ( _.isArray( config.populate ) && 0 < config.populate.length && _.isObject( config.populate[0] ) ) {
-      config.populate = config.populate;
+      // do nothing - appears good
     } else {
       config.populate = parseMixedValue( config.populate || false, relationshipFields, [] ).join( " " );
     }


### PR DESCRIPTION
Previously, we could either enable populate for a single field (including which fields will 'show') however it wasn't possible to populate and configure which fields to show for multiple relationships.

This allows you to pass an array of objects to config.populate.
