### PR TITLE
path module changes slash directions

### DIFF
--- a/lib/utils/exposeLists.js
+++ b/lib/utils/exposeLists.js
@@ -11,6 +11,7 @@ module.exports = function exposeLists( keystone,
                                     key ){
     var restConfig = parseConfig( list, config.resources[ key ] );
     if( !restConfig.hidden ){
+      if (!config.root.endsWith("/")) config.root += "/";
       var entry = url.resolve( config.root, restConfig.path );
       var methods = restConfig.methods;
       output[ key ] = {};

--- a/lib/utils/exposeLists.js
+++ b/lib/utils/exposeLists.js
@@ -1,7 +1,7 @@
 "use strict";
 var parseConfig = require( "./parseListConfig" );
 var _ = require( "lodash" );
-var path = require( "path" );
+var url = require( "url" );
 
 module.exports = function exposeLists( keystone,
                                        config ){
@@ -11,7 +11,7 @@ module.exports = function exposeLists( keystone,
                                     key ){
     var restConfig = parseConfig( list, config.resources[ key ] );
     if( !restConfig.hidden ){
-      var entry = path.join( config.root, restConfig.path );
+      var entry = url.resolve( config.root, restConfig.path );
       var methods = restConfig.methods;
       output[ key ] = {};
       _.each( methods, function( methodName ){


### PR DESCRIPTION
On windows the urls don't work because the path module converts `/`s to backslashes
I changed it so that it uses `require('url')` instead, but still accepts a config.root that doesn't end with a slash.
